### PR TITLE
Reset and fix linting configuration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,8 @@
       "Bash(npx next lint:*)",
       "Bash(npx next --version)",
       "Bash(npm test)",
-      "Bash(npm run build:*)"
+      "Bash(npm run build:*)",
+      "Bash(npm run lint:fix:*)"
     ]
   }
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,34 +1,7 @@
 {
   "extends": "stylelint-config-standard",
-  "plugins": [
-    "stylelint-order",
-    "stylelint-use-logical"
-  ],
   "rules": {
-    "alpha-value-notation": "number",
-    "csstools/use-logical": "always",
-    "custom-property-pattern": null,
-    "import-notation": "string",
-    "no-descending-specificity": null,
-    "order/order": [
-      "at-rules",
-      "custom-properties",
-      "declarations",
-      "rules"
-    ],
-    "order/properties-alphabetical-order": true,
     "selector-class-pattern": null,
-    "unit-allowed-list": [
-      "ch",
-      "em",
-      "rem",
-      "vh",
-      "vw",
-      "vmin",
-      "deg",
-      "%",
-      "s",
-      "fr"
-    ]
+    "alpha-value-notation": null
   }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,49 +1,10 @@
-import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
-import nextTypescript from "eslint-config-next/typescript";
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-import { FlatCompat } from '@eslint/eslintrc';
-import js from '@eslint/js';
-import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
-import simpleImportSort from 'eslint-plugin-simple-import-sort';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all,
-});
+import nextConfig from 'eslint-config-next';
 
 const eslintConfig = [
   {
-    ignores: ["node_modules/**", ".next/**", "out/**", "build/**", "next-env.d.ts", "*.config.js"]
+    ignores: ['node_modules/**', '.next/**', 'out/**', 'build/**'],
   },
-  ...nextCoreWebVitals,
-  ...nextTypescript,
-  ...compat.extends("prettier"),
-  {
-    plugins: {
-      'simple-import-sort': simpleImportSort,
-    },
-    rules: {
-      'react/jsx-sort-props': 'error',
-      'simple-import-sort/imports': 'error',
-    },
-  },
-  eslintPluginPrettierRecommended,
-  {
-    rules: {
-      'prettier/prettier': [
-        'error',
-        {},
-        {
-          usePrettierrc: true,
-        },
-      ],
-    },
-  }
+  ...nextConfig,
 ];
 
 export default eslintConfig;

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm test && npm run build"
+  command = "npm run lint && npm test && npm run build"
   publish = ".next"
 
 [[plugins]]

--- a/package.json
+++ b/package.json
@@ -8,11 +8,8 @@
     "start": "next start",
     "test": "jest",
     "test:watch": "jest --watch",
-    "lint": "npm run lint:js && npm run lint:style",
-    "lint:fix": "npm run lint:js:fix && npm run lint:style",
-    "lint:js": "eslint --cache --max-warnings 0 src",
-    "lint:js:fix": "eslint --fix --cache src",
-    "lint:style": "stylelint 'src/**/*.css' --fix"
+    "lint": "eslint . && stylelint 'src/**/*.css'",
+    "lint:fix": "eslint . --fix && stylelint 'src/**/*.css' --fix"
   },
   "dependencies": {
     "abcjs": "^6.6.1",

--- a/src/components/CircleFifths/CircleFifths.tsx
+++ b/src/components/CircleFifths/CircleFifths.tsx
@@ -3,12 +3,41 @@ import classnames from 'classnames';
 import { AnchorHTMLAttributes } from 'react';
 
 import { notes } from '@/constants/notes';
+import { Note } from '@/types';
 
 import { useTransposeState } from '../useTranspose';
 import styles from './CircleFifths.module.css';
 
 type NoteItemProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   position: number;
+  originalNote: Note;
+  transposedNote: Note | undefined;
+  onSelectNote: (position: number) => void;
+};
+
+const NoteItem = ({ position, children, originalNote, transposedNote, onSelectNote, ...rest }: NoteItemProps) => {
+  const isOriginalNoteMarker = originalNote.position === position;
+  let isTransposedNoteMarker = isOriginalNoteMarker;
+
+  if (transposedNote) {
+    isTransposedNoteMarker = transposedNote?.position === position;
+  }
+
+  const classes = classnames(styles.item, {
+    [styles.selected]: isOriginalNoteMarker,
+    [styles.transposed]: isTransposedNoteMarker,
+  });
+
+  return (
+    <a
+      {...rest}
+      className={classes}
+      onClick={() => onSelectNote(position)}
+      tabIndex={0}
+    >
+      {children}
+    </a>
+  );
 };
 
 export const CircleFifths = () => {
@@ -16,31 +45,6 @@ export const CircleFifths = () => {
 
   const selectNote = (position: number) => {
     setOriginalNote(notes[position]);
-  };
-
-  const NoteItem = ({ position, children, ...rest }: NoteItemProps) => {
-    const isOriginalNoteMarker = originalNote.position === position;
-    let isTransposedNoteMarker = isOriginalNoteMarker;
-
-    if (transposedNote) {
-      isTransposedNoteMarker = transposedNote?.position === position;
-    }
-
-    const classes = classnames(styles.item, {
-      [styles.selected]: isOriginalNoteMarker,
-      [styles.transposed]: isTransposedNoteMarker,
-    });
-
-    return (
-      <a
-        {...rest}
-        className={classes}
-        onClick={() => selectNote(position)}
-        tabIndex={0}
-      >
-        {children}
-      </a>
-    );
   };
 
   return (
@@ -249,8 +253,11 @@ export const CircleFifths = () => {
         <g>
           <NoteItem
             data-svg-origin="250 250"
+            onSelectNote={selectNote}
+            originalNote={originalNote}
             position={0}
             transform="matrix(0,-1,1,0,0,500)"
+            transposedNote={transposedNote}
           >
             <path
               className={styles.sector}
@@ -278,7 +285,10 @@ export const CircleFifths = () => {
           </NoteItem>
           <NoteItem
             data-svg-origin="250 250"
+            onSelectNote={selectNote}
+            originalNote={originalNote}
             position={1}
+            transposedNote={transposedNote}
             transform="matrix(0.5,-0.86602,0.86602,0.5,-91.5063509461097,341.5063509461096)"
           >
             <path
@@ -307,7 +317,10 @@ export const CircleFifths = () => {
           </NoteItem>
           <NoteItem
             data-svg-origin="250 250"
+            onSelectNote={selectNote}
+            originalNote={originalNote}
             position={2}
+            transposedNote={transposedNote}
             transform="matrix(0.86602,-0.49999,0.49999,0.86602,-91.50635094610965,158.4936490538903)"
           >
             <path
@@ -336,7 +349,10 @@ export const CircleFifths = () => {
           </NoteItem>
           <NoteItem
             data-svg-origin="250 250"
+            onSelectNote={selectNote}
+            originalNote={originalNote}
             position={3}
+            transposedNote={transposedNote}
             transform="matrix(1,0,0,1,0,0)"
           >
             <path
@@ -365,7 +381,10 @@ export const CircleFifths = () => {
           </NoteItem>
           <NoteItem
             data-svg-origin="250 250"
+            onSelectNote={selectNote}
+            originalNote={originalNote}
             position={4}
+            transposedNote={transposedNote}
             transform="matrix(0.86602,0.5,-0.5,0.86602,158.49364905389052,-91.5063509461097)"
           >
             <path
@@ -394,7 +413,10 @@ export const CircleFifths = () => {
           </NoteItem>
           <NoteItem
             data-svg-origin="250 250"
+            onSelectNote={selectNote}
+            originalNote={originalNote}
             position={5}
+            transposedNote={transposedNote}
             transform="matrix(0.5,0.86602,-0.86602,0.5,341.5063509461096,-91.5063509461097)"
           >
             <path
@@ -423,7 +445,10 @@ export const CircleFifths = () => {
           </NoteItem>
           <NoteItem
             data-svg-origin="250 250"
+            onSelectNote={selectNote}
+            originalNote={originalNote}
             position={6}
+            transposedNote={transposedNote}
             transform="matrix(0,1,-1,0,500.00000000000006,0)"
           >
             <path
@@ -452,7 +477,10 @@ export const CircleFifths = () => {
           </NoteItem>
           <NoteItem
             data-svg-origin="250 250"
+            onSelectNote={selectNote}
+            originalNote={originalNote}
             position={7}
+            transposedNote={transposedNote}
             transform="matrix(-0.5,0.86602,-0.86602,-0.5,591.5063509461097,158.4936490538905)"
           >
             <path
@@ -481,7 +509,10 @@ export const CircleFifths = () => {
           </NoteItem>
           <NoteItem
             data-svg-origin="250 250"
+            onSelectNote={selectNote}
+            originalNote={originalNote}
             position={8}
+            transposedNote={transposedNote}
             transform="matrix(-0.86602,0.5,-0.5,-0.86602,591.5063509461097,341.5063509461096)"
           >
             <path
@@ -510,7 +541,10 @@ export const CircleFifths = () => {
           </NoteItem>
           <NoteItem
             data-svg-origin="250 250"
+            onSelectNote={selectNote}
+            originalNote={originalNote}
             position={9}
+            transposedNote={transposedNote}
             transform="matrix(-1,0,0,-1,500,500)"
           >
             <path
@@ -539,7 +573,10 @@ export const CircleFifths = () => {
           </NoteItem>
           <NoteItem
             data-svg-origin="250 250"
+            onSelectNote={selectNote}
+            originalNote={originalNote}
             position={10}
+            transposedNote={transposedNote}
             transform="matrix(-0.86602,-0.49999,0.49999,-0.86602,341.5063509461097,591.5063509461097)"
           >
             <path
@@ -568,7 +605,10 @@ export const CircleFifths = () => {
           </NoteItem>
           <NoteItem
             data-svg-origin="250 250"
+            onSelectNote={selectNote}
+            originalNote={originalNote}
             position={11}
+            transposedNote={transposedNote}
             transform="matrix(-0.49999,-0.86602,0.86602,-0.49999,158.49364905389024,591.5063509461097)"
           >
             <path

--- a/src/components/MainNav/MainNav.tsx
+++ b/src/components/MainNav/MainNav.tsx
@@ -9,23 +9,24 @@ import styles from './MainNav.module.css';
 type NavLinkProps = {
   href: string;
   children: React.ReactNode;
+  pathname: string;
+};
+
+const NavLink = ({ href, children, pathname }: NavLinkProps) => {
+  return (
+    <Link
+      className={classnames(styles.link, {
+        [styles.active]: pathname === href,
+      })}
+      href={href}
+    >
+      {children}
+    </Link>
+  );
 };
 
 export const MainNav = () => {
   const pathname = usePathname();
-
-  const NavLink = ({ href, children }: NavLinkProps) => {
-    return (
-      <Link
-        className={classnames(styles.link, {
-          [styles.active]: pathname === href,
-        })}
-        href={href}
-      >
-        {children}
-      </Link>
-    );
-  };
 
   return (
     <header className={styles.header}>
@@ -36,9 +37,9 @@ export const MainNav = () => {
         <Logo className={styles.logo} />
       </Link>
       <nav className={styles.nav}>
-        <NavLink href="/">Notes</NavLink>
-        <NavLink href="/chords">Chords</NavLink>
-        <NavLink href="/scales">Scales</NavLink>
+        <NavLink href="/" pathname={pathname}>Notes</NavLink>
+        <NavLink href="/chords" pathname={pathname}>Chords</NavLink>
+        <NavLink href="/scales" pathname={pathname}>Scales</NavLink>
       </nav>
     </header>
   );

--- a/src/components/useTranspose/useTranspose.ts
+++ b/src/components/useTranspose/useTranspose.ts
@@ -18,14 +18,10 @@ export const useCreateTransposeState = () => {
   const [instrument2, setInstrument2] = useState<Instrument | undefined>(
     undefined,
   );
-  const [transposeFactor, setTransposeFactor] = useState<number>(0);
 
-  useEffect(() => {
-    const instrument1TransposeFactor = instrument1?.transposeFactor || 0;
-    const instrument2TransposeFactor = instrument2?.transposeFactor || 0;
-
-    setTransposeFactor(instrument2TransposeFactor - instrument1TransposeFactor);
-  }, [instrument1, instrument2]);
+  const instrument1TransposeFactor = instrument1?.transposeFactor || 0;
+  const instrument2TransposeFactor = instrument2?.transposeFactor || 0;
+  const transposeFactor = instrument2TransposeFactor - instrument1TransposeFactor;
 
   return {
     originalNote,


### PR DESCRIPTION
## Summary

Reset linting to use standard configurations for Next.js 16 and fixed all linting errors in the codebase.

## Configuration Changes

### ESLint
- Simplified to use standard Next.js 16 config only (`eslint-config-next`)
- Removed prettier integration, simple-import-sort plugin, and custom rules
- Uses native flat config format for ESLint 9

### Stylelint
- Simplified to use `stylelint-config-standard`
- Removed custom plugins (stylelint-order, stylelint-use-logical)
- Disabled `selector-class-pattern` to support Next.js CSS Modules camelCase convention
- Disabled `alpha-value-notation` to allow decimal transparency values

### Package Scripts
- **`lint`**: Runs ESLint + Stylelint (used in Netlify builds)
- **`lint:fix`**: Runs both linters with auto-fix flags

## Code Fixes

Fixed React best practice violations caught by the linter:

1. **CircleFifths.tsx** - Moved `NoteItem` component outside of `CircleFifths` component
   - Prevents component recreation on every render
   - Passes necessary props instead of relying on closure

2. **MainNav.tsx** - Moved `NavLink` component outside of `MainNav` component
   - Prevents component recreation on every render
   - Passes `pathname` as a prop

3. **useTranspose.ts** - Removed `useEffect` for setting `transposeFactor`
   - Calculated `transposeFactor` directly as derived state
   - Avoids cascading renders from synchronous setState in effect

## Build Changes

- **netlify.toml** - Added `npm run lint` to build command
  - Linting now runs as a pre-build check in Netlify
  - Ensures code quality before deployment

## Test Plan

- [x] `npm run lint` passes with no errors
- [x] `npm run lint:fix` works correctly
- [x] All React components still function correctly
- [x] No TypeScript errors
- [x] Ready for Netlify build checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)