### PR TITLE
Clean up transpose utilities and refactor InstrumentPicker

### DIFF
--- a/docs/TRANSPOSITION_ARCHITECTURE.md
+++ b/docs/TRANSPOSITION_ARCHITECTURE.md
@@ -1,0 +1,374 @@
+# Transposition Architecture
+
+## Overview
+
+This application uses the **circle of fifths** for all transposition calculations. Notes are represented as positions 0-11 on the circle, where position 0 is C, position 1 is G, position 2 is D, etc.
+
+## Core Concepts
+
+### Circle of Fifths Positions
+
+The circle of fifths is a fundamental music theory concept where each position represents a note a perfect fifth away from the previous:
+
+- Position 0: C
+- Position 1: G
+- Position 2: D
+- Position 3: A
+- Position 4: E
+- Position 5: B
+- Position 6: F♯/G♭
+- Position 7: D♭
+- Position 8: A♭
+- Position 9: E♭
+- Position 10: B♭
+- Position 11: F
+
+### Transpose Factor
+
+The transpose factor is the difference between two instruments' transposition factors:
+
+```typescript
+transposeFactor = instrument2.transposeFactor - instrument1.transposeFactor
+```
+
+**Examples:**
+- Piano (C, factor 0) to Alto Sax (E♭, factor 3): `transposeFactor = 3`
+- Alto Sax (E♭, factor 3) to Tenor Sax (B♭, factor 2): `transposeFactor = -1`
+- Trumpet (B♭, factor 2) to French Horn (F, factor 1): `transposeFactor = -1`
+
+## Core Utilities
+
+### `transposeNote(position, factor)`
+
+**File:** `src/utils/transposeNote.ts`
+
+Core circle of fifths arithmetic.
+
+- **Input:** Note position (0-11) and transpose factor
+- **Output:** New position (0-11)
+- **Algorithm:** `(position + factor) % 12` with negative handling
+- **Use case:** Low-level transposition calculation
+
+**Example:**
+```typescript
+transposeNote(0, 2)  // Returns 2 (C → D)
+transposeNote(1, 1)  // Returns 2 (G → D)
+transposeNote(0, -1) // Returns 11 (C → F)
+```
+
+### `transposeNoteList(identifiers, factor)`
+
+**File:** `src/utils/transposeNoteList.ts`
+
+Transpose multiple notes at once.
+
+- **Input:** Array of note identifier strings, transpose factor
+- **Output:** Array of Note objects
+- **Use case:** Transposing scales, chords, or any note collection
+
+**Example:**
+```typescript
+transposeNoteList(['c', 'e', 'g'], 2)
+// Returns [Note for D, Note for F#, Note for A]
+
+transposeNoteList(['c', 'd', 'e', 'f', 'g', 'a', 'b'], 1)
+// Transposes C major scale to G major
+```
+
+### `circleFifthsPositionToSemitones(position)`
+
+**File:** `src/utils/circleFifthsPositionToSemitones.ts`
+
+Convert circle of fifths position to semitones from C.
+
+- **Input:** Circle of fifths position
+- **Output:** Semitones from C (can be negative)
+- **Use case:** ABCJS notation rendering
+
+**Example:**
+```typescript
+circleFifthsPositionToSemitones(0)  // 0 (C)
+circleFifthsPositionToSemitones(1)  // 7 (G is 7 semitones above C)
+circleFifthsPositionToSemitones(3)  // -3 (A, represented as -3 for ABCJS)
+```
+
+**Note:** This function uses a lookup table to map circle positions to semitones. Some values are negative because ABCJS notation prefers certain enharmonic spellings.
+
+### `transposeNoteSemitones(originalNote, transposedNote)` (Deprecated)
+
+**File:** `src/utils/transposeNoteSemitones.ts`
+
+⚠️ **Deprecated:** Use `circleFifthsPositionToSemitones` instead.
+
+This function is now a wrapper that calls `circleFifthsPositionToSemitones`. It's maintained for backward compatibility but should not be used in new code.
+
+## State Management
+
+### XState Machine (`machine.ts`)
+
+**File:** `src/components/useTranspose/machine.ts`
+
+The transpose machine is the **single source of truth** for:
+
+- `originalNote` - The reference note selected by the user
+- `transposedNote` - **Derived state**, calculated automatically
+- `transposeFactor` - **Derived state**, calculated from instruments
+- `instrument1` and `instrument2` - Selected instruments
+
+**Important:** The machine automatically recalculates `transposedNote` and `transposeFactor` whenever instruments or originalNote change. Components should **never** recalculate these values manually.
+
+#### Helper Functions
+
+- `calculateTransposeFactor(instrument1, instrument2)` - Computes the difference between instrument transpose factors
+- `calculateTransposedNote(originalNote, instrument1, instrument2)` - Calculates the resulting note using `transposeNote()`
+- `computeDerivedValues()` - Consolidates both calculations
+
+## React Hooks
+
+### `useTranspose()`
+
+**File:** `src/components/useTranspose/useTranspose.ts`
+
+Provides access to the machine state and actions.
+
+**Returns:**
+- State: `originalNote`, `transposedNote`, `instrument1`, `instrument2`, `transposeFactor`
+- Actions: `setOriginalNote()`, `setInstrument1()`, `setInstrument2()`, `clearInstrument1()`, `clearInstrument2()`
+
+**Example:**
+```typescript
+const { originalNote, transposedNote, transposeFactor, setOriginalNote } = useTranspose();
+```
+
+### `useTransposedNotes({ noteIdentifiers, transposeFactor })`
+
+**File:** `src/components/useTransposedNotes.ts`
+
+Convenience hook for transposing a list of notes.
+
+- **Input:** Note identifiers (strings) and transpose factor
+- **Output:** Memoized array of Note objects
+- **Use case:** Use this in components instead of manually calling `transposeNote`
+
+**Example:**
+```typescript
+const { transposeFactor } = useTranspose();
+const transposedNotes = useTransposedNotes({
+  noteIdentifiers: ['c', 'e', 'g'],
+  transposeFactor
+});
+// transposedNotes is a memoized array of Note objects
+```
+
+### `useTransposeSemitones({ originalNote, transposedNote })`
+
+**File:** `src/components/useTransposeSemitones.ts`
+
+Converts positions to semitones for ABCJS notation rendering.
+
+- **Input:** Original and transposed Note objects
+- **Output:** `transposeSemitonesOriginal` and `transposeSemitonesTransposed`
+- **Use case:** TransposeNotation component for rendering musical notation
+
+**Example:**
+```typescript
+const { originalNote, transposedNote } = useTranspose();
+const { transposeSemitonesOriginal, transposeSemitonesTransposed } = useTransposeSemitones({
+  originalNote,
+  transposedNote
+});
+// Pass these semitone values to the Notation component
+```
+
+## Component Patterns
+
+### NotesDisplay
+
+**File:** `src/components/NotesDisplay/NotesDisplay.tsx`
+
+Shows original or transposed notes.
+
+**Pattern:**
+```typescript
+const { originalNote, transposedNote } = useTranspose();
+const displayFactor = isTransposed
+  ? transposedNote?.position ?? 0
+  : originalNote.position;
+const displayNotes = useTransposedNotes({
+  noteIdentifiers: notes,
+  transposeFactor: displayFactor
+});
+```
+
+### TransposeNotation
+
+**File:** `src/components/TransposeNotation.tsx`
+
+Shows musical notation with ABCJS.
+
+**Pattern:**
+```typescript
+const { originalNote, transposedNote } = useTranspose();
+const { transposeSemitonesOriginal, transposeSemitonesTransposed } = useTransposeSemitones({
+  originalNote,
+  transposedNote
+});
+// Pass semitones to Notation component
+<Notation transpose={transposeSemitonesOriginal} />
+```
+
+## Migration Guide
+
+### ❌ Old Pattern (Don't Do This)
+
+```typescript
+// Manually calling transposeNote in component
+const displayNote = notesMap[
+  transposeNote(noteObject.position, transposedNote?.position ?? 0)
+];
+```
+
+**Problems:**
+- Duplicates logic that the machine already computed
+- Hard to maintain
+- Not memoized, recalculates on every render
+- Scattered transposition logic
+
+### ✅ New Pattern (Do This)
+
+```typescript
+// Use the hook
+const displayNotes = useTransposedNotes({
+  noteIdentifiers: notes,
+  transposeFactor
+});
+```
+
+**Benefits:**
+- Reuses tested utility functions
+- Memoized for performance
+- Centralized logic
+- Easy to understand and maintain
+
+## Testing
+
+### Test Files
+
+- `transposeNote.test.ts` - Core arithmetic, includes real-world examples (tenor/alto sax)
+- `transposeNoteList.test.ts` - List transposition, scales, chords, edge cases
+- `circleFifthsPositionToSemitones.test.ts` - Position to semitone conversion, music theory verification
+
+### Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run specific test files
+npm test -- transposeNote
+npm test -- transposeNoteList
+npm test -- circleFifthsPositionToSemitones
+
+# Run in watch mode
+npm test -- --watch
+```
+
+## Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ User selects original note and instruments in UI                │
+└────────────────────────┬────────────────────────────────────────┘
+                         │
+                         ▼
+        ┌────────────────────────────────────┐
+        │    TransposeMachine (XState)       │
+        │  • originalNote                    │
+        │  • instrument1, instrument2        │
+        │  • transposeFactor (DERIVED)       │
+        │  • transposedNote (DERIVED)        │
+        └────────────────┬───────────────────┘
+                         │
+        ┌────────────────┴─────────────┬──────────────────────┐
+        │                              │                      │
+        ▼                              ▼                      ▼
+┌──────────────────────┐  ┌─────────────────────┐  ┌──────────────────┐
+│ useTranspose()       │  │useTransposeSemitones│  │  useTransposedNotes│
+│                      │  │                     │  │                  │
+│ Returns:            │  │ Returns:            │  │ Takes:           │
+│ • State values      │  │ • Semitone values   │  │ • Note IDs       │
+│ • Action methods    │  │   for ABCJS         │  │ • Transpose factor│
+└──────────────────────┘  └──────┬──────────────┘  └──────┬───────────┘
+                                 │                        │
+                                 ▼                        ▼
+                    ┌─────────────────────┐  ┌──────────────────────┐
+                    │ TransposeNotation   │  │  NotesDisplay        │
+                    │                     │  │                      │
+                    │ Uses semitones for  │  │ Shows transposed     │
+                    │ ABCJS rendering     │  │ note collections     │
+                    └─────────────────────┘  └──────────────────────┘
+```
+
+## Best Practices
+
+1. **Always use the machine as source of truth** - Don't recalculate transposition in components
+2. **Use hooks over direct utility calls** - Hooks provide memoization and better patterns
+3. **Prefer `useTransposedNotes` for lists** - Don't manually loop and call `transposeNote`
+4. **Use `circleFifthsPositionToSemitones` for ABCJS** - Not for general transposition
+5. **Test with real-world scenarios** - Include instrument transposition examples in tests
+
+## Common Pitfalls
+
+### ❌ Pitfall 1: Recalculating in Components
+
+```typescript
+// Don't do this
+const transposedPosition = transposeNote(note.position, transposeFactor);
+```
+
+The machine already calculated this! Use the derived state instead.
+
+### ❌ Pitfall 2: Confusing Position with Semitones
+
+```typescript
+// Don't do this
+const semitones = transposeNote(0, 5); // This returns circle position, not semitones!
+```
+
+Use `circleFifthsPositionToSemitones` for semitone conversion.
+
+### ❌ Pitfall 3: Manual Loops
+
+```typescript
+// Don't do this
+notes.map(id => {
+  const note = findNote(id);
+  return transposeNote(note.position, factor);
+});
+```
+
+Use `useTransposedNotes` hook or `transposeNoteList` utility instead.
+
+## Future Enhancements
+
+Potential improvements to consider:
+
+1. **Type safety** - Create branded types: `CirclePosition` vs `Semitones`
+2. **Caching** - Add caching layer for frequently used transpositions
+3. **Validation** - Add runtime validation for note identifiers
+4. **Error handling** - Better handling of invalid inputs
+5. **Performance** - Profile and optimize hot paths if needed
+
+## Related Documentation
+
+- [XState Documentation](https://xstate.js.org/)
+- [Circle of Fifths (Music Theory)](https://en.wikipedia.org/wiki/Circle_of_fifths)
+- [ABCJS Notation Library](https://abcjs.net/)
+
+## Questions?
+
+If you have questions about the transposition architecture, check:
+1. This documentation
+2. JSDoc comments in the source files
+3. Test files for usage examples
+4. The implementation plan at `.claude/plans/witty-twirling-hearth.md`

--- a/src/components/InstrumentSelector/InstrumentPicker.tsx
+++ b/src/components/InstrumentSelector/InstrumentPicker.tsx
@@ -1,9 +1,9 @@
 import { RefObject, useRef } from 'react';
 
-import { InstrumentItem } from '@/components/InstrumentItem';
-import { instrumentsArray } from '@/constants/instruments';
+import { instruments } from '@/constants/instruments';
 import { Instrument } from '@/types';
 
+import { InstrumentPickerButton } from './InstrumentPickerButton';
 import styles from './InstrumentPicker.module.css';
 
 type InstrumentPickerProps = {
@@ -48,18 +48,26 @@ export const InstrumentPicker = ({
         <div className={styles.container}>
           <button className={styles.close}>close</button>
           <div className={styles.list}>
-            {instrumentsArray.map((instrument) => (
-              <button
-                className={styles.button}
-                key={instrument?.iconName}
-                onClick={() => handleSelect(instrument)}
-              >
-                <InstrumentItem
-                  instrument={instrument}
-                  stretch
-                />
-              </button>
-            ))}
+            <InstrumentPickerButton instrument={instruments.piano} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.altoClarinet} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.altoSax} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.bariSax} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.baritoneHorn} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.bassClarinet} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.cello} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.clarinet} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.doubleBass} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.flute} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.guitar} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.frenchHorn} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.oboe} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.sopranoSax} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.tenorSax} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.trombone} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.trumpet} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.tuba} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.viola} onSelect={handleSelect} />
+            <InstrumentPickerButton instrument={instruments.violin} onSelect={handleSelect} />
           </div>
         </div>
       </form>

--- a/src/components/InstrumentSelector/InstrumentPickerButton.tsx
+++ b/src/components/InstrumentSelector/InstrumentPickerButton.tsx
@@ -1,0 +1,24 @@
+import { InstrumentItem } from '@/components/InstrumentItem';
+import { Instrument } from '@/types';
+
+import styles from './InstrumentPicker.module.css';
+
+type InstrumentPickerButtonProps = {
+  instrument: Instrument;
+  onSelect: (instrument: Instrument) => void;
+};
+
+export const InstrumentPickerButton = ({
+  instrument,
+  onSelect,
+}: InstrumentPickerButtonProps) => (
+  <button
+    className={styles.button}
+    onClick={() => onSelect(instrument)}
+  >
+    <InstrumentItem
+      instrument={instrument}
+      stretch
+    />
+  </button>
+);

--- a/src/components/NotesDisplay/NotesDisplay.tsx
+++ b/src/components/NotesDisplay/NotesDisplay.tsx
@@ -1,11 +1,10 @@
 import classnames from 'classnames';
 
-import { notes as notesMap } from '@/constants/notes';
 import { Container } from '@/types';
-import { transposeNote } from '@/utils/transposeNote';
 
 import { Note } from '../Note';
 import { useTranspose } from '../useTranspose';
+import { useTransposedNotes } from '../useTransposedNotes';
 import styles from './NotesDisplay.module.css';
 
 type NotesDisplayProps = Container & {
@@ -21,52 +20,32 @@ export const NotesDisplay = ({
 }: NotesDisplayProps) => {
   const { originalNote, transposedNote } = useTranspose();
 
+  // Calculate the appropriate transpose factor based on whether we're showing
+  // original or transposed notes
+  const displayTransposeFactor = isTransposed
+    ? transposedNote?.position ?? 0
+    : originalNote.position;
+
+  // Use the hook to get transposed notes
+  const displayNotes = useTransposedNotes({
+    noteIdentifiers: notes,
+    transposeFactor: displayTransposeFactor,
+  });
+
   const label = isTransposed ? 'Transposed' : 'Original';
 
   return (
     <div className={classnames(styles.notesContainer, className)}>
       <strong>{label}:</strong>
       <div className={styles.notes}>
-        {notes.map((note) => {
-          const noteObject =
-            notesMap.find(
-              (noteObject) =>
-                noteObject.note.toLowerCase() === note.toLowerCase(),
-            ) || notesMap[0];
-
-          if (isTransposed) {
-            const displayNote =
-              notesMap[
-                transposeNote(
-                  noteObject.position,
-                  transposedNote?.position ?? 0,
-                )
-              ] || notesMap[0];
-
-            return (
-              <Note
-                className={styles.note}
-                key={note}
-                note={displayNote}
-                showBothAccidentals
-              />
-            );
-          }
-
-          const displayNote =
-            notesMap[
-              transposeNote(noteObject.position, originalNote.position)
-            ] || notesMap[0];
-
-          return (
-            <Note
-              className={styles.note}
-              key={note}
-              note={displayNote}
-              showBothAccidentals
-            />
-          );
-        })}
+        {displayNotes.map((note, index) => (
+          <Note
+            className={styles.note}
+            key={`${notes[index]}-${index}`}
+            note={note}
+            showBothAccidentals
+          />
+        ))}
       </div>
     </div>
   );

--- a/src/components/useTransposeSemitones.ts
+++ b/src/components/useTransposeSemitones.ts
@@ -1,24 +1,28 @@
 import { useMemo } from 'react';
 
 import { Note } from '@/types';
-import { transposeNoteSemitones } from '@/utils/transposeNoteSemitones';
+import { circleFifthsPositionToSemitones } from '@/utils/circleFifthsPositionToSemitones';
 
 type UseTransposeSemitonesParams = {
   originalNote: Note;
   transposedNote?: Note;
 };
 
+/**
+ * Hook that converts circle of fifths positions to semitones for ABCJS notation.
+ * Used by TransposeNotation component for rendering musical notation.
+ */
 export const useTransposeSemitones = ({
   originalNote,
   transposedNote,
 }: UseTransposeSemitonesParams) => {
   const transposeSemitonesOriginal = useMemo(
-    () => transposeNoteSemitones(0, originalNote.position),
+    () => circleFifthsPositionToSemitones(originalNote.position),
     [originalNote.position],
   );
 
   const transposeSemitonesTransposed = useMemo(
-    () => transposeNoteSemitones(0, transposedNote?.position || 0),
+    () => circleFifthsPositionToSemitones(transposedNote?.position || 0),
     [transposedNote?.position],
   );
 

--- a/src/components/useTransposedNotes.ts
+++ b/src/components/useTransposedNotes.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+
+import { Note } from '@/types';
+import { transposeNoteList } from '@/utils/transposeNoteList';
+
+type UseTransposedNotesParams = {
+  noteIdentifiers: string[];
+  transposeFactor: number;
+};
+
+/**
+ * Hook that transposes a list of note identifiers by a given factor.
+ * Returns memoized array of Note objects.
+ *
+ * @param noteIdentifiers - Array of note identifier strings
+ * @param transposeFactor - Number of steps to transpose on circle of fifths
+ * @returns Memoized array of transposed Note objects
+ *
+ * @example
+ * // In a component:
+ * const { transposeFactor } = useTranspose();
+ * const transposedNotes = useTransposedNotes({
+ *   noteIdentifiers: ['c', 'e', 'g'],
+ *   transposeFactor
+ * });
+ */
+export function useTransposedNotes({
+  noteIdentifiers,
+  transposeFactor,
+}: UseTransposedNotesParams): Note[] {
+  return useMemo(
+    () => transposeNoteList(noteIdentifiers, transposeFactor),
+    [noteIdentifiers, transposeFactor],
+  );
+}

--- a/src/constants/instruments.ts
+++ b/src/constants/instruments.ts
@@ -147,8 +147,6 @@ export const instruments = {
   },
 } as InstrumentList;
 
-export const instrumentsArray = Object.values(instruments);
-
 /**
  * Find an instrument by its key (e.g., 'piano', 'clarinet', 'altoSax')
  */

--- a/src/utils/circleFifthsPositionToSemitones.test.ts
+++ b/src/utils/circleFifthsPositionToSemitones.test.ts
@@ -1,0 +1,111 @@
+import { circleFifthsPositionToSemitones } from './circleFifthsPositionToSemitones';
+
+describe('circleFifthsPositionToSemitones', () => {
+  describe('basic positions', () => {
+    it('should return 0 semitones for position 0 (C)', () => {
+      expect(circleFifthsPositionToSemitones(0)).toBe(0);
+    });
+
+    it('should return 7 semitones for position 1 (G)', () => {
+      expect(circleFifthsPositionToSemitones(1)).toBe(7);
+    });
+
+    it('should return 2 semitones for position 2 (D)', () => {
+      expect(circleFifthsPositionToSemitones(2)).toBe(2);
+    });
+
+    it('should return -3 semitones for position 3 (A)', () => {
+      expect(circleFifthsPositionToSemitones(3)).toBe(-3);
+    });
+
+    it('should return 4 semitones for position 4 (E)', () => {
+      expect(circleFifthsPositionToSemitones(4)).toBe(4);
+    });
+
+    it('should return -1 semitones for position 5 (B)', () => {
+      expect(circleFifthsPositionToSemitones(5)).toBe(-1);
+    });
+
+    it('should return 6 semitones for position 6 (F#/Gb)', () => {
+      expect(circleFifthsPositionToSemitones(6)).toBe(6);
+    });
+
+    it('should return 1 semitone for position 7 (Db)', () => {
+      expect(circleFifthsPositionToSemitones(7)).toBe(1);
+    });
+
+    it('should return 8 semitones for position 8 (Ab)', () => {
+      expect(circleFifthsPositionToSemitones(8)).toBe(8);
+    });
+
+    it('should return 3 semitones for position 9 (Eb)', () => {
+      expect(circleFifthsPositionToSemitones(9)).toBe(3);
+    });
+
+    it('should return -2 semitones for position 10 (Bb)', () => {
+      expect(circleFifthsPositionToSemitones(10)).toBe(-2);
+    });
+
+    it('should return 5 semitones for position 11 (F)', () => {
+      expect(circleFifthsPositionToSemitones(11)).toBe(5);
+    });
+  });
+
+  describe('wrapping positions', () => {
+    it('should handle position 12 (wraps to 0)', () => {
+      expect(circleFifthsPositionToSemitones(12)).toBe(0);
+    });
+
+    it('should handle position 13 (wraps to 1)', () => {
+      expect(circleFifthsPositionToSemitones(13)).toBe(7);
+    });
+
+    it('should handle position 24 (two full circles)', () => {
+      expect(circleFifthsPositionToSemitones(24)).toBe(0);
+    });
+
+    it('should handle position 25', () => {
+      expect(circleFifthsPositionToSemitones(25)).toBe(7);
+    });
+  });
+
+  describe('negative positions', () => {
+    it('should handle negative position -1 (wraps to 11, F)', () => {
+      expect(circleFifthsPositionToSemitones(-1)).toBe(5);
+    });
+
+    it('should handle negative position -2 (wraps to 10, Bb)', () => {
+      expect(circleFifthsPositionToSemitones(-2)).toBe(-2);
+    });
+
+    it('should handle negative position -12 (wraps to 0)', () => {
+      expect(circleFifthsPositionToSemitones(-12)).toBe(0);
+    });
+
+    it('should handle negative position -13 (wraps to 11)', () => {
+      expect(circleFifthsPositionToSemitones(-13)).toBe(5);
+    });
+  });
+
+  describe('music theory verification', () => {
+    it('should correctly map perfect fifth (C to G)', () => {
+      // C is position 0, G is position 1
+      expect(circleFifthsPositionToSemitones(1)).toBe(7); // 7 semitones = perfect fifth
+    });
+
+    it('should correctly map whole step (C to D)', () => {
+      // C is position 0, D is position 2
+      expect(circleFifthsPositionToSemitones(2)).toBe(2); // 2 semitones = whole step
+    });
+
+    it('should correctly map major third (C to E)', () => {
+      // C is position 0, E is position 4
+      expect(circleFifthsPositionToSemitones(4)).toBe(4); // 4 semitones = major third
+    });
+
+    it('should correctly map perfect fourth (C to F)', () => {
+      // C is position 0, F is position 11
+      expect(circleFifthsPositionToSemitones(11)).toBe(5); // 5 semitones = perfect fourth
+    });
+  });
+});

--- a/src/utils/circleFifthsPositionToSemitones.ts
+++ b/src/utils/circleFifthsPositionToSemitones.ts
@@ -1,0 +1,44 @@
+// Maps circle of fifths positions to semitones from C
+const circleFifthsSemitoneMap = {
+  0: 0, // C
+  1: 7, // G
+  2: 2, // D
+  3: -3, // A
+  4: 4, // E
+  5: -1, // B
+  6: 6, // F#/Gb
+  7: 1, // Db
+  8: 8, // Ab
+  9: 3, // Eb
+  10: -2, // Bb
+  11: 5, // F
+};
+
+const FULL_CIRCLE = 12;
+
+/**
+ * Converts a circle of fifths position to semitones from C.
+ * Used for ABCJS notation rendering which requires semitone transposition.
+ *
+ * @param position - Circle of fifths position (0-11)
+ * @returns Number of semitones from C (can be negative)
+ *
+ * @example
+ * circleFifthsPositionToSemitones(1) // 7 (G is 7 semitones above C)
+ * circleFifthsPositionToSemitones(3) // -3 (A is 9 semitones above C, represented as -3)
+ */
+export function circleFifthsPositionToSemitones(position: number): number {
+  // Normalize position to 0-11 range
+  let normalizedPosition = position % FULL_CIRCLE;
+
+  if (normalizedPosition < 0) {
+    normalizedPosition += FULL_CIRCLE;
+  }
+
+  // Convert -0 to 0
+  normalizedPosition = normalizedPosition === 0 ? 0 : normalizedPosition;
+
+  return circleFifthsSemitoneMap[
+    normalizedPosition as keyof typeof circleFifthsSemitoneMap
+  ];
+}

--- a/src/utils/transposeNoteList.test.ts
+++ b/src/utils/transposeNoteList.test.ts
@@ -1,0 +1,119 @@
+import { transposeNoteList } from './transposeNoteList';
+
+describe('transposeNoteList', () => {
+  describe('basic transposition', () => {
+    it('should transpose a major chord up by 2 steps', () => {
+      const result = transposeNoteList(['c', 'e', 'g'], 2);
+      expect(result.map((n) => n.note)).toEqual(['d', 'gFlat', 'a']);
+    });
+
+    it('should handle case-insensitive identifiers', () => {
+      const result = transposeNoteList(['C', 'E', 'G'], 2);
+      expect(result.map((n) => n.note)).toEqual(['d', 'gFlat', 'a']);
+    });
+
+    it('should handle mixed case identifiers', () => {
+      const result = transposeNoteList(['c', 'EFLAT', 'G'], 1);
+      expect(result.map((n) => n.note)).toEqual(['g', 'bFlat', 'd']);
+    });
+
+    it('should transpose by 0 and return same notes', () => {
+      const result = transposeNoteList(['c', 'e', 'g'], 0);
+      expect(result.map((n) => n.note)).toEqual(['c', 'e', 'g']);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty array', () => {
+      const result = transposeNoteList([], 5);
+      expect(result).toEqual([]);
+    });
+
+    it('should default to C for unknown identifiers', () => {
+      const result = transposeNoteList(['unknown'], 0);
+      expect(result[0].note).toBe('c');
+    });
+
+    it('should handle unknown identifiers with transposition', () => {
+      const result = transposeNoteList(['invalid'], 2);
+      expect(result[0].note).toBe('d');
+    });
+  });
+
+  describe('negative transpose factors', () => {
+    it('should handle negative transpose factors', () => {
+      const result = transposeNoteList(['c', 'e', 'g'], -2);
+      expect(result.map((n) => n.note)).toEqual(['bFlat', 'd', 'f']);
+    });
+
+    it('should transpose down by 1 step', () => {
+      const result = transposeNoteList(['g'], -1);
+      expect(result[0].note).toBe('c');
+    });
+  });
+
+  describe('circle wrapping', () => {
+    it('should handle wrapping around circle of fifths', () => {
+      const result = transposeNoteList(['c'], 13); // One full circle + 1
+      expect(result[0].note).toBe('g');
+    });
+
+    it('should handle multiple full circles', () => {
+      const result = transposeNoteList(['c'], 24); // Two full circles
+      expect(result[0].note).toBe('c');
+    });
+
+    it('should handle large negative transpose factors', () => {
+      const result = transposeNoteList(['c'], -13);
+      expect(result[0].note).toBe('f');
+    });
+  });
+
+  describe('real-world scenarios', () => {
+    it('should transpose C major scale to D major', () => {
+      const cMajorScale = ['c', 'd', 'e', 'f', 'g', 'a', 'b'];
+      const result = transposeNoteList(cMajorScale, 2);
+      expect(result.map((n) => n.note)).toEqual([
+        'd',
+        'e',
+        'gFlat',
+        'g',
+        'a',
+        'b',
+        'dFlat',
+      ]);
+    });
+
+    it('should transpose minor chord progression', () => {
+      const minorChord = ['c', 'eFlat', 'g'];
+      const result = transposeNoteList(minorChord, 3);
+      expect(result.map((n) => n.note)).toEqual(['a', 'c', 'e']);
+    });
+
+    it('should transpose from C to G (up 1 fifth)', () => {
+      const notes = ['c', 'e', 'g'];
+      const result = transposeNoteList(notes, 1);
+      expect(result.map((n) => n.note)).toEqual(['g', 'b', 'd']);
+    });
+
+    it('should transpose from piano (C) to alto sax (Eb)', () => {
+      // Alto sax transposes up 3 steps on circle of fifths
+      const pianoNotes = ['c', 'd', 'e'];
+      const result = transposeNoteList(pianoNotes, 3);
+      expect(result.map((n) => n.note)).toEqual(['a', 'b', 'dFlat']);
+    });
+  });
+
+  describe('maintains array order', () => {
+    it('should preserve order of notes in array', () => {
+      const notes = ['g', 'c', 'e', 'b', 'd'];
+      const result = transposeNoteList(notes, 1);
+      expect(result.length).toBe(5);
+      expect(result[0].note).toBe('d'); // g + 1
+      expect(result[1].note).toBe('g'); // c + 1
+      expect(result[2].note).toBe('b'); // e + 1
+      expect(result[3].note).toBe('gFlat'); // b + 1
+      expect(result[4].note).toBe('a'); // d + 1
+    });
+  });
+});

--- a/src/utils/transposeNoteList.ts
+++ b/src/utils/transposeNoteList.ts
@@ -1,0 +1,36 @@
+import { notes } from '@/constants/notes';
+import { Note } from '@/types';
+import { transposeNote } from './transposeNote';
+
+/**
+ * Transposes a list of note identifiers by a given transpose factor.
+ *
+ * @param noteIdentifiers - Array of note identifier strings (e.g., ['c', 'd', 'eFlat'])
+ * @param transposeFactor - Number of steps to transpose on the circle of fifths
+ * @returns Array of Note objects after transposition
+ *
+ * @example
+ * // Transpose ['C', 'E', 'G'] up by 2 steps (to D major chord)
+ * transposeNoteList(['c', 'e', 'g'], 2)
+ * // Returns [Note for D, Note for F#, Note for A]
+ */
+export function transposeNoteList(
+  noteIdentifiers: string[],
+  transposeFactor: number,
+): Note[] {
+  return noteIdentifiers.map((identifier) => {
+    // Find the original note by identifier (case-insensitive)
+    const originalNote = notes.find(
+      (note) => note.note.toLowerCase() === identifier.toLowerCase(),
+    );
+
+    // Default to C if not found
+    const notePosition = originalNote?.position ?? 0;
+
+    // Calculate transposed position
+    const transposedPosition = transposeNote(notePosition, transposeFactor);
+
+    // Return the transposed note object
+    return notes[transposedPosition];
+  });
+}

--- a/src/utils/transposeNoteSemitones.ts
+++ b/src/utils/transposeNoteSemitones.ts
@@ -1,39 +1,17 @@
-const circleFifthsSemitoneMap = {
-  0: 0, // C
-  1: 7, // G
-  2: 2, // D
-  3: -3, // A
-  4: 4, // E
-  5: -1, // B
-  6: 6, // F#
-  7: 1, // Db
-  8: 8, // Ab
-  9: 3, // Eb
-  10: -2, // Bb
-  11: 5, // F
-};
+import { circleFifthsPositionToSemitones } from './circleFifthsPositionToSemitones';
 
-const FULL_CIRCLE = 12;
-
+/**
+ * @deprecated Use circleFifthsPositionToSemitones instead.
+ * This function always receives 0 as the first parameter in practice.
+ *
+ * Transposes from originalNote to transposedNote and returns semitone difference.
+ * In practice, originalNote is always 0 (C), so this is equivalent to
+ * circleFifthsPositionToSemitones(transposedNote).
+ */
 export function transposeNoteSemitones(
   originalNote: number,
   transposedNote: number,
-) {
-  let stepsMoved = transposedNote - originalNote;
-
-  // Wrap stepsMoved to be within 0-11 range using modulo arithmetic
-  stepsMoved = stepsMoved % FULL_CIRCLE;
-
-  // Handle negative results by adding FULL_CIRCLE
-  if (stepsMoved < 0) {
-    stepsMoved += FULL_CIRCLE;
-  }
-
-  // Convert -0 to 0 (JavaScript quirk)
-  stepsMoved = stepsMoved === 0 ? 0 : stepsMoved;
-
-  const semitones =
-    circleFifthsSemitoneMap[stepsMoved as keyof typeof circleFifthsSemitoneMap];
-
-  return semitones;
+): number {
+  const stepsMoved = transposedNote - originalNote;
+  return circleFifthsPositionToSemitones(stepsMoved);
 }


### PR DESCRIPTION
## Summary
- **Refactored transposition utilities**: extracted `circleFifthsPositionToSemitones` and `transposeNoteList` into standalone, tested modules; simplified `transposeNoteSemitones` and `useTransposeSemitones`; added `useTransposedNotes` hook to encapsulate note transposition logic in `NotesDisplay`
- **Refactored InstrumentPicker**: replaced `instrumentsArray.map()` with explicit JSX using a new reusable `InstrumentPickerButton` component; removed the `instrumentsArray` export
- **Added tests**: new test suites for `circleFifthsPositionToSemitones` and `transposeNoteList` (107 tests passing)
- **Added docs**: `TRANSPOSITION_ARCHITECTURE.md` documenting the circle-of-fifths transposition system

## Test plan
- [x] All 107 unit tests pass (`npm test`)
- [x] Production build succeeds (`npm run build`)
- [ ] Visually verify instrument picker renders all 20 instruments correctly
- [ ] Verify transposition still works end-to-end for scales and chords

🤖 Generated with [Claude Code](https://claude.com/claude-code)